### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/josvandergouw/bc1e5521-1de1-4691-98a1-cfc7035275e6/2f3246e8-dc49-4bba-a281-b4f0b406bd93/_apis/work/boardbadge/aec29e88-da84-43be-9cc0-d7fe90ddff7a)](https://dev.azure.com/josvandergouw/bc1e5521-1de1-4691-98a1-cfc7035275e6/_boards/board/t/2f3246e8-dc49-4bba-a281-b4f0b406bd93/Microsoft.RequirementCategory)
 - 👋 Hi, I’m @JosvanderGouw
 - 👀 I’m interested in ...
 - 🌱 I’m currently learning working with Github and Azure DevOps 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/josvandergouw/bc1e5521-1de1-4691-98a1-cfc7035275e6/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.